### PR TITLE
tp permission in plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,7 +18,7 @@ commands:
 
   tp:
     description: Allows players to teleport using their tokens.
-    permission: lyttleessentials.tp.others
+    permission: lyttleessentials.tp
 
   tpaccept:
     description: Accept incoming requests


### PR DESCRIPTION
tp permission in plugin.yml was set wrong causing the need for two permisison entries for player to make tp requests